### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,4 +20,4 @@ To run the suite::
 
     sh run.sh
 
-Refer to the `asv documentation <https://asv.readthedocs.org/>`_ for more info.
+Refer to the `asv documentation <https://asv.readthedocs.io/>`_ for more info.

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,7 @@
     "project": "schematics",
 
     // The project's homepage
-    "project_url": "https://schematics.readthedocs.org/",
+    "project_url": "https://schematics.readthedocs.io/",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
